### PR TITLE
adds script to sync directory information with the FDP 

### DIFF
--- a/sync_directory_with_fdp.py
+++ b/sync_directory_with_fdp.py
@@ -2,8 +2,8 @@
 Script to synchronize the BBMRI Directory data of biobanks and collections with their FAIR Data Point/DCAT representation.
 It gets the data of biobanks and collections from a Molgenis instance of the Directory, converts it and upload the
 converted one into another Molgenis instance. The Molgenis instance can be the same or different. The destination
-instance needs to be deployed with the FDP instance already deployed. Also, the FDP must have the fdp_Catalog already
-created.
+instance needs the FDP EMX model and the "bbmri-directory" FDP_Catalog (i.e., the FDP Catalog with data of the directory)
+already deployed
 """
 
 from collections import OrderedDict

--- a/sync_directory_with_fdp.py
+++ b/sync_directory_with_fdp.py
@@ -171,8 +171,8 @@ def get_records_to_add(biobank_data, session, directory_prefix):
             'title': c['name'],
             'biobank': biobank_data["id"],
             'description': c['description'] if 'description' in c else None,
-            'type': [t['id'] for t in collection['type'] if get_collection_type_ontology_code(t['id']) is not None],
-            'theme': [d['id'] for d in collection['diagnosis_available']],
+            'type': [t['id'] for t in c['type'] if get_collection_type_ontology_code(t['id']) is not None],
+            'theme': [d['id'] for d in c['diagnosis_available']],
             'service': c['record_service']['id'] if 'record_service' in c else None
         } for c in biobank_data['collections']],
         FDP_IRI: missing_iris,

--- a/sync_directory_with_fdp.py
+++ b/sync_directory_with_fdp.py
@@ -1,0 +1,159 @@
+from molgenis import client
+from molgenis.client import MolgenisRequestError
+
+molgenisURL = 'http://localhost:82'
+directoryURL = 'http://localhost:82'
+
+MOLGENIS_URL = f'{molgenisURL}'  # URL of the molgenis to query
+DIRECTORY_URL = f'{directoryURL}'  # URL of the directory
+
+BBMRI_BIOBANK_ENTITY = 'eu_bbmri_eric_biobanks'
+BBMRI_COLLECTION_ENTITY = 'eu_bbmri_eric_collections'
+
+FDP_BIOBANK_ENTITY = 'fdp_Biobank'
+FDP_COLLECTION_ENTITY = 'fdp_Collection'
+
+ORPHA_ONTOLOGY_PREFIX = 'http://www.orpha.net/ORDO/Orphanet_'
+ORPHA_DIRECTORY_PREFIX = 'ORPHA:'
+ICD_10_ONTOLOGY_PREFIX = 'http://purl.bioontology.org/ontology/ICD10/'
+ICD_10_DIRECTORY_PREFIX = 'urn:miriam:icd:'
+
+BIOBANKS_ATTRIBUTES = 'id,name,acronym,description,country,juridical_person,collections,contact'
+BIOBANKS_EXPAND_ATTRIBUTES = 'country,juridical_person,collections,contact'
+COLLECTIONS_ATTRIBUTES = 'id,name,description,biobank,diagnosis_available,country,parent_collection'
+COLLECTIONS_EXPAND_ATTRIBUTES = 'biobank,diagnosis_available,country'
+
+COLLECTION_TYPES_ONTOLOGIES = {
+    'BIRTH_COHORT': 'http://purl.obolibrary.org/obo/OBI_0002614',
+    'CASE_CONTROL': 'http://purl.obolibrary.org/obo/OBIB_0000693',
+    'COHORT': 'http://purl.obolibrary.org/obo/OBIB_0000696',
+    'CROSS_SECTIONAL': 'http://purl.obolibrary.org/obo/OBIB_0000694',
+    'DISEASE_SPECIFIC': 'http://purl.obolibrary.org/obo/OBI_0002615',
+    'HOSPITAL': None,
+    'IMAGE': None,
+    'LONGITUDINAL': 'http://purl.obolibrary.org/obo/OBIB_0000695',
+    'NON_HUMAN': None,
+    'OTHER': None,
+    'POPULATION_BASED': 'http://purl.obolibrary.org/obo/OBIB_0000698',
+    'PROSPECTIVE_COLLECTION': None,
+    'QUALITY_CONTROL': 'http://purl.obolibrary.org/obo/OBIB_0000699',
+    'RD': None,
+    'SAMPLE': None,
+    'TWIN_STUDY': 'http://purl.obolibrary.org/obo/OBIB_0000700'
+}
+
+
+def _get_missing_biobanks(session, **kwargs):
+    print("Getting source entities from {}".format(BBMRI_BIOBANK_ENTITY))
+    source_records = session.get(BBMRI_BIOBANK_ENTITY, **kwargs)
+    print("Getting ids already present")
+    dest_records_ids = [r['identifier'] for r in session.get(FDP_BIOBANK_ENTITY, attributes='identifier')]
+    new_records = [sr for sr in source_records if sr['id'] not in dest_records_ids]
+    print("Found {} new records to insert".format(len(new_records)))
+    return source_records
+
+
+def _add_new_records(session, entity, records):
+    created_records = []
+    for i in range(0, len(records), 1000):
+        try:
+            created_records.extend(session.add_all(entity, records[i:i + 1000]))
+        except MolgenisRequestError as ex:
+            print("Error adding records")
+            print(ex)
+    print("Added {} record(s) of type {}".format(len(created_records), entity))
+
+
+def _convert_country(country):
+    return 'GB' if country == 'UK' else country
+
+
+def _get_disease_ontology_code(disease_code):
+    if ORPHA_DIRECTORY_PREFIX in disease_code:
+        return disease_code.replace(ORPHA_ONTOLOGY_PREFIX, ORPHA_ONTOLOGY_PREFIX)
+    if ICD_10_DIRECTORY_PREFIX in disease_code:
+        return disease_code.replace(ICD_10_DIRECTORY_PREFIX, ICD_10_ONTOLOGY_PREFIX)
+
+
+def _get_collection_type_ontology_code(collection_type):
+    return COLLECTION_TYPES_ONTOLOGIES.get(collection_type, None)
+
+
+def get_records_to_add(biobank_data, session):
+    missing_iris = []
+    for c in biobank_data['collections']:
+        for d in c['diagnosis_available']:
+            try:
+                session.get_by_id('fdp_IRI', d['id'], attributes='id')
+            except MolgenisRequestError:
+                missing_iris.append((d['id'], _get_disease_ontology_code(d['id'])))
+
+        for t in c['type']:
+            try:
+                session.get_by_id('fdp_IRI', t['id'], attributes='id')
+            except MolgenisRequestError:
+                ontology_code = _get_collection_type_ontology_code(t['id'])
+                if ontology_code is not None:
+                    missing_iris.append((t['id'], ontology_code))
+
+    return {
+        'fdp_Biobank': {
+            'IRI': f'{DIRECTORY_URL}/api/fdp/fdp_Biobank/{biobank_data["id"]}',
+            'catalog': 'bbmri-directory',  # TODO: get it dynamically
+            'identifier': biobank_data['id'],
+            'title': biobank_data['name'],
+            'acronym': biobank_data['acronym'] if 'acronym' in biobank_data else None,
+            'description': biobank_data['description'] if 'description' in biobank_data else None,
+            'publisher': f'{biobank_data["id"]}-pub',
+            'landingPage': f'{DIRECTORY_URL}/#/biobank/{biobank_data["id"]}',
+            'contactPoint': f'{biobank_data["id"]}-cp' if 'contact' in biobank_data else None,
+            'country': _convert_country(biobank_data['country']['id'])
+        },
+        'fdp_Publisher': {
+            'identifier': f'{biobank_data["id"]}-pub',
+            'label': biobank_data['juridical_person']
+        },
+        'fdp_ContactPointIndividual': {
+            'identifier': f'{biobank_data["id"]}-cp',
+            'email': f'mailto:{biobank_data["contact"]["email"]}' if 'contact' in biobank_data else '',
+            'address': '',
+            'telephone': '',
+        },
+        'fdp_Collection': [{
+            'identifier': c['id'],
+            'title': c['name'],
+            'biobank': biobank_data["id"],
+            'description': c['description'] if 'description' in c else None,
+            'type': [t['id'] for t in c['type'] if _get_collection_type_ontology_code(t['id']) is not None],
+            'theme': [d['id'] for d in c['diagnosis_available']]
+        } for c in biobank_data['collections']],
+        'fdp_IRI': missing_iris
+    }
+
+
+def sync_biobanks(session, **kwargs):
+    missing_biobanks = _get_missing_biobanks(session, attributes=BIOBANKS_ATTRIBUTES,
+                                             expand=BIOBANKS_EXPAND_ATTRIBUTES, **kwargs)
+    biobanks = []
+    publishers = []
+    contacts = []
+    collections = []
+    iris = set()
+    for b in missing_biobanks:
+        records = get_records_to_add(b, session)
+        biobanks.append(records['fdp_Biobank'])
+        publishers.append(records['fdp_Publisher'])
+        contacts.append(records['fdp_ContactPointIndividual'])
+        collections.extend(records['fdp_Collection'])
+        iris.update(records['fdp_IRI'])
+
+    _add_new_records(session, 'fdp_Publisher', publishers)
+    _add_new_records(session, 'fdp_ContactPointIndividual', contacts)
+    _add_new_records(session, 'fdp_IRI', [{'id': i[0], 'IRI': i[1]} for i in iris])
+    _add_new_records(session, 'fdp_Biobank', biobanks)
+    _add_new_records(session, 'fdp_Collection', collections)
+
+s = client.Session(MOLGENIS_URL)
+s.login('admin', 'admin')
+
+sync_biobanks(s, num=1)

--- a/sync_directory_with_fdp.py
+++ b/sync_directory_with_fdp.py
@@ -248,7 +248,7 @@ def get_records_to_add(biobank_data, session, directory_prefix):
             'title': c['name'],
             'description': c['description'] if 'description' in c else None,
             'diseases': [d['id'].replace("urn:miriam:icd:", "ICD10:") for d in c['diagnosis_available']],
-            'theme': 'EU:HEALTH',
+            'theme': ['EU:HEALTH'] + [d['id'] for d in c['diagnosis_available']],
             'type': '',
             'landingPage': f'{directory_prefix}/#/collection/{c["id"]}',
             'contactPoint': f'{c["contact"]["id"]}' if 'contact' in c else None,
@@ -372,4 +372,4 @@ if __name__ == '__main__':
     s = client.Session(args.molgenis_url)
     s.login(args.molgenis_user, args.molgenis_password)
 
-    sync(s, directory_prefix, args.reset)
+    sync(s, directory_prefix, args.reset, q="id==bbmri-eric:ID:EU_BBMRI-ERIC")

--- a/sync_directory_with_fdp.py
+++ b/sync_directory_with_fdp.py
@@ -4,6 +4,20 @@ It gets the data of biobanks and collections from a Molgenis instance of the Dir
 converted one into another Molgenis instance. The Molgenis instance can be the same or different. The destination
 instance needs the FDP EMX model and the "bbmri-directory" FDP_Catalog (i.e., the FDP Catalog with data of the directory)
 already deployed
+
+--------------------------------------------------------------------------------------------------------------------------
+
+Authors
+
+ - Vittorio Meloni <vittorio.meloni@crs4.it>
+
+Acknowledgments:
+
+This work has been partially funded by the following sources:
+
+ - The European Joint Programme on Rare Disease (EJPRD) project (grant agreement N. 825575);
+
+and has evolved within the context of the BBMRI-ERIC Common Service IT.
 """
 from collections import OrderedDict
 

--- a/sync_directory_with_fdp.py
+++ b/sync_directory_with_fdp.py
@@ -50,11 +50,12 @@ COLLECTION_TYPES_ONTOLOGIES = {
     'TWIN_STUDY': 'http://purl.obolibrary.org/obo/OBIB_0000700'
 }
 
-"""
-It gets the data from the source Molgenis and filters the one that are already it the destination Molgenis.
-If reset flag is True it doesn't filter the biobanks to add 
-"""
+
 def get_missing_biobanks(session, reset, **kwargs):
+    """
+    It gets the data from the source Molgenis and filters the one that are already it the destination Molgenis.
+    If reset flag is True it doesn't filter the biobanks to add
+    """
     print("Getting source entities from {}".format(BBMRI_BIOBANK_ENTITY))
     source_records = session.get(BBMRI_BIOBANK_ENTITY, **kwargs)
     # if reset is True the missing biobanks are all
@@ -68,14 +69,14 @@ def get_missing_biobanks(session, reset, **kwargs):
     return new_records
 
 
-"""
-Send converted data to the destination
-
-:params session: Molgenis session to use
-:params entity: the name of Molgenis entity type of the records to add 
-:params records: lists of dictionary with data of the FDP entity to add
-"""
 def create_records(session, entity, records):
+    """
+    Send converted data to the destination
+
+    :params session: Molgenis session to use
+    :params entity: the name of Molgenis entity type of the records to add
+    :params records: lists of dictionary with data of the FDP entity to add
+    """
     created_records = []
     for i in range(0, len(records), 1000):
         try:
@@ -86,14 +87,14 @@ def create_records(session, entity, records):
     print("Added {} record(s) of type {}".format(len(created_records), entity))
 
 
-"""
-Delete records in the destination Molgenis. Used when reset flag is True
-
-:params session: Molgenis session to use
-:params entity: the name of Molgenis entity type of the records to delete
-:params records_ids: the ids of the records of type :entity: to delete 
-"""
 def delete_records(session, entity, records_ids):
+    """
+    Delete records in the destination Molgenis. Used when reset flag is True
+
+    :params session: Molgenis session to use
+    :params entity: the name of Molgenis entity type of the records to delete
+    :params records_ids: the ids of the records of type :entity: to delete
+    """
     removed_records = []
     for i in range(0, len(records_ids), 1000):
         try:
@@ -105,40 +106,40 @@ def delete_records(session, entity, records_ids):
     print(f"Removed {len(removed_records)} of type {entity}")
 
 
-"""
-Returns the country code correspondent to the country in input 
-"""
 def get_country(country):
+    """
+    Returns the country code correspondent to the country in input
+    """
     return 'GB' if country == 'UK' else country
 
 
-"""
-Returns the IRI of the disease code to use in the FDP
-"""
 def get_disease_ontology_code(disease_code):
+    """
+    Returns the IRI of the disease code to use in the FDP
+    """
     if ORPHA_DIRECTORY_PREFIX in disease_code:
         return disease_code.replace(ORPHA_DIRECTORY_PREFIX, ORPHA_ONTOLOGY_PREFIX)
     if ICD_10_DIRECTORY_PREFIX in disease_code:
         return disease_code.replace(ICD_10_DIRECTORY_PREFIX, ICD_10_ONTOLOGY_PREFIX)
 
 
-"""
-Return the IRI of the collection type
-
-:params collection_type: the collection type code in the directory 
-"""
 def get_collection_type_ontology_code(collection_type):
+    """
+    Return the IRI of the collection type
+
+    :params collection_type: the collection type code in the directory
+    """
     return COLLECTION_TYPES_ONTOLOGIES.get(collection_type, None)
 
 
-"""
-Gets the contact data of the contact with id :contact_id: from the source Molgenis and 
-returns the FDP corresponding FDP record
-
-:params session: Molgenis session to use
-:params contact_id: the id of the contact in the Directory
-"""
 def get_contact_record(session, contact_id):
+    """
+    Gets the contact data of the contact with id :contact_id: from the source Molgenis and
+    returns the FDP corresponding FDP record
+
+    :params session: Molgenis session to use
+    :params contact_id: the id of the contact in the Directory
+    """
     contact = session.get_by_id(BBMRI_CONTACT_ENTITY, contact_id)
     return (
         f'{contact["id"]}',
@@ -151,17 +152,18 @@ def get_contact_record(session, contact_id):
     )
 
 
-"""
-It generates the FDP records related to a biobank from the representation of the biobank in the Directory.
-It returns a dictionary with data for entities:
-fdp_Biobank: data of the Biobank as organization
-fdp_BiobankOrganization: data of the Jurystic Person that manage the Biobank
-fdp_Collection: list of collections of the biobank
-fdp_Contacts: contact of the biobank and the collections to add
-fdp_IRI: codes of diseases and collection types (if not already present in the destination)
-fdp_DataService: data related to the Data service, if present
-"""
 def get_records_to_add(biobank_data, session, directory_prefix):
+    """
+    It generates the FDP records related to a biobank from the representation of the biobank in the Directory.
+    It returns a dictionary with data for entities:
+    fdp_Biobank: data of the Biobank as organization
+    fdp_BiobankOrganization: data of the Jurystic Person that manage the Biobank
+    fdp_Collection: list of collections of the biobank
+    fdp_Contacts: contact of the biobank and the collections to add
+    fdp_IRI: codes of diseases and collection types (if not already present in the destination)
+    fdp_DataService: data related to the Data service, if present
+    """
+
     missing_iris = []
     data_services = []
     contacts = []
@@ -244,10 +246,10 @@ def update_catalog(session, new_collections):
 
     session.update_one(FDP_CATALOG, 'bbmri-directory', 'collection', list(collections))
 
-"""
-Main function that gets the data of the missing biobanks, convert it and upload the new records.
-"""
 def sync(session, directory_prefix, reset, **kwargs):
+    """
+    Main function that gets the data of the missing biobanks, convert it and upload the new records.
+    """
     # it gets the missing biobanks
     missing_biobanks = get_missing_biobanks(session, reset=reset, attributes=BIOBANKS_ATTRIBUTES,
                                             expand=BIOBANKS_EXPAND_ATTRIBUTES, **kwargs)

--- a/sync_directory_with_fdp.py
+++ b/sync_directory_with_fdp.py
@@ -159,7 +159,7 @@ def get_records_to_add(biobank_data, session, directory_prefix):
     return res
 
 
-def sync(session, reset, directory_prefix, **kwargs):
+def sync(session, directory_prefix, reset, **kwargs):
     missing_biobanks = get_missing_biobanks(session, reset=reset, attributes=BIOBANKS_ATTRIBUTES,
                                             expand=BIOBANKS_EXPAND_ATTRIBUTES,
                                             **kwargs)


### PR DESCRIPTION
Script to synchronize the BBMRI Directory data of biobanks and collections with their FAIR Data Point/DCAT representation.
It gets the data of biobanks and collections from a Molgenis instance of the Directory, converts it and upload the
converted one into another Molgenis instance. The Molgenis instance can be the same or different. The destination
instance needs the FDP EMX model and the "bbmri-directory" FDP_Catalog (i.e., the FDP Catalog with data of the directory)
already deployed 