### PR TITLE
Plugin to check subcollection network membership matching parent collection

### DIFF
--- a/checks/SubcollectionNetworkMembership.py
+++ b/checks/SubcollectionNetworkMembership.py
@@ -1,0 +1,40 @@
+# vim:ts=8:sw=8:tw=0:noet
+"""Plugin to check that subcollections belong to the same network as their parent collections"""
+
+import logging as log
+
+from yapsy.IPlugin import IPlugin
+from customwarnings import DataCheckWarningLevel, DataCheckWarning, DataCheckEntityType
+from directory import Directory
+
+
+class SubcollectionNetworkMembership(IPlugin):
+    """Check whether subcollections belong to the same network as their parent collections"""
+
+    def check(self, directory: Directory, _):
+        """Do the actual checking"""
+        warnings = []
+        log.info("Running subcollection network membership checks (SubcollectionNetworkMembership)")
+        for collection in directory.getCollections():
+            if "parent_collection" in collection:
+                # Is a subcollection
+                parent_id = collection["parent_collection"]["id"]
+                parent = directory.getCollectionById(parent_id)
+                if "network" in parent:
+                    # Parent collection is member of one or more networks
+                    for network in parent["network"]:
+                        if "network" not in collection or network not in collection["network"]:
+                            warnings.append(
+                                DataCheckWarning(
+                                    self.__class__.__name__,
+                                    "",
+                                    directory.getCollectionNN(collection["id"]),
+                                    DataCheckWarningLevel.WARNING,
+                                    collection["id"],
+                                    DataCheckEntityType.COLLECTION,
+                                    str(collection["withdrawn"]),
+                                    f"Subcollection is not part of network {network['id']},"
+                                    f" even though parent collection {parent_id} is.",
+                                )
+                            )
+        return warnings

--- a/checks/SubcollectionNetworkMembership.yapsy-plugin
+++ b/checks/SubcollectionNetworkMembership.yapsy-plugin
@@ -1,0 +1,9 @@
+[Core]
+Name = Check that subcollections belong to the same network as their parent collections
+Module = SubcollectionNetworkMembership
+
+[Documentation]
+Author = Hessel Haagsma
+Version = 1.0
+Description = Check that subcollections belong to the same network as their parent collections
+


### PR DESCRIPTION
If a collection is part of a network then the sub collections should also be part of the network. However, changing the data is up to the biobank. Therefore, we change the quality script to add a new check whether network membership of subcollections matches their parent collection. 

This adds a plugin to do that.