### PR TITLE
Fix NameError: biobank_covid undefined in first loop of COVID check

### DIFF
--- a/checks/COVID.py
+++ b/checks/COVID.py
@@ -180,6 +180,10 @@ class COVID(IPlugin):
 			if 'capabilities' in biobank:
 				for c in biobank['capabilities']:
 					biobank_capabilities.append(c['id'])
+			biobank_covid = []
+			if 'covid19biobank' in biobank:
+				for c in biobank['covid19biobank']:
+					biobank_covid.append(c['id'])
 			biobank_networks = []
 			if 'network' in biobank:
 				for n in biobank['network']:


### PR DESCRIPTION
## Summary
- `biobank_covid` was only defined in the second biobank loop (line 307) but referenced in the first collection loop (line 300) when checking BSL2/BSL3 for collections with infectious materials
- This caused a `NameError` crash for `:COVID19` collections containing FECES but not NASAL_SWAB or THROAT_SWAB
- Added extraction from `biobank['covid19biobank']` in the first loop, matching the established pattern in the exporter scripts