### PR TITLE
Fix stale biobank_capabilities in second loop of COVID check

### DIFF
--- a/checks/COVID.py
+++ b/checks/COVID.py
@@ -305,6 +305,10 @@ class COVID(IPlugin):
 
 		for biobank in dir.getBiobanks():
 			biobank_covid = []
+			biobank_capabilities = []
+			if 'capabilities' in biobank:
+				for c in biobank['capabilities']:
+					biobank_capabilities.append(c['id'])
 			biobank_networks = []
 			if 'network' in biobank:
 				for n in biobank['network']:


### PR DESCRIPTION
## Summary
- `biobank_capabilities` was computed only in the first collection loop but referenced in the second biobank loop, where it retained the stale value from the last iteration of the first loop
- Every biobank in the second pass was checked against the wrong capabilities
- Now recomputed per-biobank in the second loop