### PR TITLE
Fix isObesityCode individual check to match obesity_diag_ranges E65-E68

### DIFF
--- a/icd10codeshelper.py
+++ b/icd10codeshelper.py
@@ -55,7 +55,7 @@ class ICD10CodesHelper:
       m = re.search(r'^(?P<block>[A-Z])(?P<code>\d{1,2})(\.(?P<subcode>\d+))?$', code)
       if m:
          log.debug("ICD-10 block detected: %s, code: %s, subcode %s" % (m.group('block'), m.group('code'), m.group('subcode')))
-         if m.group('block') == 'E' and (int(m.group('code')) == 66):
+         if m.group('block') == 'E' and (65 <= int(m.group('code')) <= 68):
             return True
          else:
             return False


### PR DESCRIPTION
## Summary
- `isObesityCode` only matched E66 for individual codes, while `obesity_diag_ranges` declares `E65-E68`. This meant passing `"E65-E68"` as a range returned `True`, but passing `"E65"` individually returned `False` — inconsistent behavior.
- Widened the individual code check to match the full E65-E68 range.

## Note for reviewer
Strictly speaking, only E66 is obesity per se. E65 (localized adiposity), E67 (other hyperalimentation), and E68 (sequelae of hyperalimentation) are related but not obesity diagnoses. The alternative fix would be to narrow `obesity_diag_ranges` from `['E65-E68']` to `['E66-E66']` and keep the individual check as `== 66`. Either way, the two code paths need to agree.